### PR TITLE
Avoid indeterminate order in Schema Map

### DIFF
--- a/testsuite/shared/src/main/java/org/wildfly/test/distribution/validation/AbstractValidationUnitTest.java
+++ b/testsuite/shared/src/main/java/org/wildfly/test/distribution/validation/AbstractValidationUnitTest.java
@@ -45,6 +45,7 @@ import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.LinkedList;
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
@@ -83,8 +84,8 @@ public class AbstractValidationUnitTest {
 
     private static final Set<String> EXCLUDED_SCHEMA_FILES = new HashSet<>();
     private static final Set<String> FUTURE_SCHEMA_FILES = new HashSet<>();
-    private static final Map<String, File> JBOSS_SCHEMAS_MAP = new HashMap<>();
-    private static final Map<String, File> CURRENT_JBOSS_SCHEMAS_MAP = new HashMap<>();
+    private static final Map<String, File> JBOSS_SCHEMAS_MAP = new LinkedHashMap<>();
+    private static final Map<String, File> CURRENT_JBOSS_SCHEMAS_MAP = new LinkedHashMap<>();
     private static final Source[] SCHEMA_SOURCES;
     private static final Map<String, String> NAMESPACE_MAP = new HashMap<>();
     private static final Map<String, String> OUTDATED_NAMESPACES = new HashMap<>();


### PR DESCRIPTION
### Description
In `StandardConfigsXMLValidationUnitTestCase`, the test cases call the method `parseXML()` implemented in the class `AbstractValidationUnitTestAbstractValidationUnitTest`. Notice that the class initialized the static `JBOSS_SCHEMAS_MAP` and `CURRENT_JBOSS_SCHEMAS_MAP` as normal `HashMap`, and the code uses the default `HashMap.iterator` to  loop through `JBOSS_SCHEMAS_MAP` to  set up `CURRENT_JBOSS_SCHEMAS_MAP`, and then loop through `CURRENT_JBOSS_SCHEMAS_MAP` to configure `SCHEMA_SOURCES`. As `HashMap` class makes no guarantees as to the order of iterator of the map, `SCHEMA_SOURCES` may suffer from non-deterministic order. As a result, an error may be raised in `parseXML()` when setting up schema from `SCHEMA_SOURCES`.

### How we Discovered the Problem and Steps to Reproduce
The `NonDex` Maven plugin permutes `HashMap` iterators just as what happened between Java 7 and 8, and it reports test flakiness in a sample run. To reproduce, run `mvn edu.illinois:nondex-maven-plugin:2.1.1:nondex -Dtest=StandardConfigsXMLValidationUnitTestCase` in the `list` submodule after building the project.

## Tests that Fails in a Different JVM
```
StandardConfigsXMLValidationUnitTestCase#testHost
StandardConfigsXMLValidationUnitTestCase#testSecondary
StandardConfigsXMLValidationUnitTestCase#testPrimary
StandardConfigsXMLValidationUnitTestCase#testDomain
StandardConfigsXMLValidationUnitTestCase#testStandalone
StandardConfigsXMLValidationUnitTestCase#testStandaloneHA
StandardConfigsXMLValidationUnitTestCase#testStandaloneFull
StandardConfigsXMLValidationUnitTestCase#testStandaloneMicroProfile
StandardConfigsXMLValidationUnitTestCase#testStandaloneMicroProfileHA
```

### Sample Failure (testHost)
The HashMap default iteration order changed between Java 7 and 8, breaking lots of unit tests. Our NonDex plugin https://github.com/TestingResearchIllinois/NonDex permutes these orders just as between Java 7 and 8, and it produces the following output in a sample run: 
```
[INFO] Running org.wildfly.dist.subsystem.xml.StandardConfigsXMLValidationUnitTestCase.testHost
[ERROR] Tests run: 1, Failures: 1, Errors: 0, Skipped: 0, Time elapsed: 0.341 s <<< FAILURE! - in org.wildfly.dist.subsystem.xml.StandardConfigsXMLValidationUnitTestCase
[ERROR] testHost(org.wildfly.dist.subsystem.xml.StandardConfigsXMLValidationUnitTestCase)  Time elapsed: 0.339 s  <<< FAILURE!
java.lang.AssertionError: 
56:38 sch-props-correct.2: A schema cannot contain two global components with the same name; this schema contains two occurrences of 'https://jakarta.ee/xml/ns/jakartaee,descriptionGroup'. a possible cause may be that a subsystem is not using the most up to date schema.
Possible line:     </jvms>
	at org.junit.Assert.fail(Assert.java:89)
[ERROR] Failures: 
[ERROR]   StandardConfigsXMLValidationUnitTestCase.testHost:37->AbstractValidationUnitTest.parseXml:452 56:38 sch-props-correct.2: A schema cannot contain two global components with the same name; this schema contains two occurrences of 'https://jakarta.ee/xml/ns/jakartaee,descriptionGroup'. a possible cause may be that a subsystem is not using the most up to date schema.
Possible line:     </jvms>
[INFO] 
[ERROR] Tests run: 1, Failures: 1, Errors: 0, Skipped: 0
```

### Suggested Fix
Use `LinkedHashMap` instead to initialize the static schemas Map, so that the insertion order will be persistent. Also, iterating through `LinkedHashMap` will be more efficient.


