### PR TITLE
fix: fix flaky test in org.wildfly.clustering.marshalling.spi.ExternalizerUtilTestCase#testUnmodifiableCollection

### DIFF
--- a/clustering/marshalling/spi/src/main/java/org/wildfly/clustering/marshalling/spi/DecoratorExternalizer.java
+++ b/clustering/marshalling/spi/src/main/java/org/wildfly/clustering/marshalling/spi/DecoratorExternalizer.java
@@ -27,6 +27,8 @@ import java.io.ObjectInput;
 import java.io.ObjectOutput;
 import java.lang.reflect.Field;
 import java.security.PrivilegedAction;
+import java.util.Arrays;
+import java.util.Comparator;
 import java.util.function.UnaryOperator;
 
 import org.wildfly.clustering.marshalling.Externalizer;
@@ -65,7 +67,9 @@ public class DecoratorExternalizer<T> implements Externalizer<T>, ParametricPriv
     }
 
     static Field findDecoratedField(Class<?> decoratorClass, Class<?> decoratedClass) {
-        for (Field field : decoratorClass.getDeclaredFields()) {
+        Field[] declaredFields = decoratorClass.getDeclaredFields();
+        Arrays.sort(declaredFields, Comparator.comparing(Field::getName));
+        for (Field field : declaredFields) {
             if (field.getType().isAssignableFrom(decoratedClass)) {
                 return field;
             }


### PR DESCRIPTION
## Problem:
<!-- Explain the context and why you're making that change. What is the problem you're trying to solve? In some cases there is not a problem and this can be thought of being the motivation for your change. -->
The passing of the test is depending on the order of the returned values of the declaredFields method. The first one which meets the criteria is returned – if more fields which meet the criteria are available, the test might fail because it is non-deterministic in which order the array is returned. 
The flaky test was found by using the [NonDex](https://mvnrepository.com/artifact/edu.illinois/nondex-maven-plugin) tool.

```
[ERROR] Failures: 
[ERROR]   ExternalizerUtilTestCase>AbstractUtilTestCase.testUnmodifiableCollection:447 Marshaller size = 290, Default serialization size = 290
``` 

This shows the trace to the bug: 
<!--https://github.com/hofi1/wildfly/blob/9617adf6f2acca84334b6053781586088ba5b264/clustering/marshalling/api/src/test/java/org/wildfly/clustering/marshalling/AbstractUtilTestCase.java#L445-L448-->
https://github.com/zzjas/wildfly/blob/7344cc997854141cb01f40c972a5192414099b10/clustering/marshalling/api/src/test/java/org/wildfly/clustering/marshalling/AbstractUtilTestCase.java#L445-L448

using the factory defined in ExternaliterUtilTestCase depending on the UtilExternalizerProvider.class
https://github.com/zzjas/wildfly/blob/7344cc997854141cb01f40c972a5192414099b10/clustering/marshalling/spi/src/test/java/org/wildfly/clustering/marshalling/spi/ExternalizerUtilTestCase.java#L33-L38

<!-- and the test uses this createTester method
https://github.com/zzjas/wildfly/blob/7344cc997854141cb01f40c972a5192414099b10/clustering/marshalling/api/src/test/java/org/wildfly/clustering/marshalling/ExternalizerTesterFactory.java#L47-L50 -->

and the UNMODIFIABLE_COLLECTION enum in the UtilExternalizerProvider.class is defined in the following way
https://github.com/zzjas/wildfly/blob/7344cc997854141cb01f40c972a5192414099b10/clustering/marshalling/spi/src/main/java/org/wildfly/clustering/marshalling/spi/util/UtilExternalizerProvider.java#L121

which calls at creation 
https://github.com/zzjas/wildfly/blob/7344cc997854141cb01f40c972a5192414099b10/clustering/marshalling/spi/src/main/java/org/wildfly/clustering/marshalling/spi/SynchronizedDecoratorExternalizer.java#L44-L46

and results in the reflect call in the DecoratorExternalizer
https://github.com/zzjas/wildfly/blob/7344cc997854141cb01f40c972a5192414099b10/clustering/marshalling/spi/src/main/java/org/wildfly/clustering/marshalling/spi/DecoratorExternalizer.java#L55-L67

and calls 
https://github.com/zzjas/wildfly/blob/7344cc997854141cb01f40c972a5192414099b10/clustering/marshalling/spi/src/main/java/org/wildfly/clustering/marshalling/spi/DecoratorExternalizer.java#L67-L78

## Solution:
Order the array before iterating over it – this returns the elements in the array in a deterministic way.
<!--https://github.com/hofi1/wildfly/blob/9617adf6f2acca84334b6053781586088ba5b264/clustering/marshalling/spi/src/main/java/org/wildfly/clustering/marshalling/spi/DecoratorExternalizer.java#L69-L82-->
https://github.com/zzjas/wildfly/blob/9617adf6f2acca84334b6053781586088ba5b264/clustering/marshalling/spi/src/main/java/org/wildfly/clustering/marshalling/spi/DecoratorExternalizer.java#L69-L82

## Result:
<!-- What will change as a result of your pull request? Note that sometimes this section is unnecessary because it is self-explanatory based on the solution. -->
The test is deterministic and not flaky. This improves the quality of the test and reduces the time to search for the bug during future development.

## Reproduce:
```shell
mvn -pl clustering/marshalling/spi edu.illinois:nondex-maven-plugin:2.1.1:nondex -Dtest=org.wildfly.clustering.marshalling.spi.ExternalizerUtilTestCase#testUnmodifiableCollection
``` 

