### PR TITLE
Fix Flaky AbstractValidationUnitTest

### DIFF
--- a/testsuite/shared/src/main/java/org/wildfly/test/distribution/validation/AbstractValidationUnitTest.java
+++ b/testsuite/shared/src/main/java/org/wildfly/test/distribution/validation/AbstractValidationUnitTest.java
@@ -42,8 +42,10 @@ import java.nio.file.Paths;
 import java.nio.file.SimpleFileVisitor;
 import java.nio.file.attribute.BasicFileAttributes;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.HashMap;
 import java.util.HashSet;
+import java.util.LinkedHashMap;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
@@ -83,8 +85,8 @@ public class AbstractValidationUnitTest {
 
     private static final Set<String> EXCLUDED_SCHEMA_FILES = new HashSet<>();
     private static final Set<String> FUTURE_SCHEMA_FILES = new HashSet<>();
-    private static final Map<String, File> JBOSS_SCHEMAS_MAP = new HashMap<>();
-    private static final Map<String, File> CURRENT_JBOSS_SCHEMAS_MAP = new HashMap<>();
+    private static final Map<String, File> JBOSS_SCHEMAS_MAP = new LinkedHashMap<>();
+    private static final Map<String, File> CURRENT_JBOSS_SCHEMAS_MAP = new LinkedHashMap<>();
     private static final Source[] SCHEMA_SOURCES;
     private static final Map<String, String> NAMESPACE_MAP = new HashMap<>();
     private static final Map<String, String> OUTDATED_NAMESPACES = new HashMap<>();
@@ -169,6 +171,7 @@ public class AbstractValidationUnitTest {
             final File schemaDir = new File(JBOSS_DIST_DIR, SCHEMAS_LOCATION);
 
             final File[] xsds = schemaDir.listFiles(new SchemaFilter(EXCLUDED_SCHEMA_FILES.toArray(new String[0])));
+            Arrays.sort(xsds);
             for (File xsd : xsds) {
                 JBOSS_SCHEMAS_MAP.put(xsd.getName(), xsd);
             }


### PR DESCRIPTION
*__NOTE__*: Wildfly requires all PR's to have related JIRA's, where the PR simple links to the JIRA. This tentative PR represents the JIRA ticket we would open, _if_ approved (Logs are uploaded to [CampusWire](https://campuswire.com/c/G7A0E96FD/feed/716)).

Before moving onto the JIRA, there are 47 tests that are fixed (it looks duplicated, but java inheritance is at play)

wildfly-preview-dist (13)
    - org.wildfly.dist.subsystem.xml.StandardConfigsXMLValidationUnitTestCase#testHostSecondary
    - org.wildfly.dist.subsystem.xml.StandardConfigsXMLValidationUnitTestCase#testStandalone
    - org.wildfly.dist.subsystem.xml.StandardConfigsXMLValidationUnitTestCase#testHost
    - org.wildfly.dist.subsystem.xml.StandardConfigsXMLValidationUnitTestCase#testStandaloneHA
    - org.wildfly.dist.subsystem.xml.StandardConfigsXMLValidationUnitTestCase#testStandaloneJTS
    - org.wildfly.dist.subsystem.xml.StandardConfigsXMLValidationUnitTestCase#testStandaloneRTS
    - org.wildfly.dist.subsystem.xml.StandardConfigsXMLValidationUnitTestCase#testStandaloneXTS
    - org.wildfly.dist.subsystem.xml.StandardConfigsXMLValidationUnitTestCase#testStandaloneMinimalistic
    - org.wildfly.dist.subsystem.xml.StandardConfigsXMLValidationUnitTestCase#testStandaloneActiveMQEmbedded
    - org.wildfly.dist.subsystem.xml.StandardConfigsXMLValidationUnitTestCase#testHostPrimary
    - org.wildfly.dist.subsystem.xml.StandardConfigsXMLValidationUnitTestCase#testStandaloneFull
    - org.wildfly.dist.subsystem.xml.StandardConfigsXMLValidationUnitTestCase#testDomain
    - org.wildfly.dist.subsystem.xml.StandardConfigsXMLValidationUnitTestCase#testStandaloneGenericJMS

wildfly-dist (18)
    - org.wildfly.dist.subsystem.xml.StandardConfigsXMLValidationUnitTestCase#testStandaloneEC2FullHA
    - org.wildfly.dist.subsystem.xml.StandardConfigsXMLValidationUnitTestCase#testHostSecondary
    - org.wildfly.dist.subsystem.xml.StandardConfigsXMLValidationUnitTestCase#testStandalone
    - org.wildfly.dist.subsystem.xml.StandardConfigsXMLValidationUnitTestCase#testHost
    - org.wildfly.dist.subsystem.xml.StandardConfigsXMLValidationUnitTestCase#testStandaloneHA
    - org.wildfly.dist.subsystem.xml.StandardConfigsXMLValidationUnitTestCase#testStandaloneJTS
    - org.wildfly.dist.subsystem.xml.StandardConfigsXMLValidationUnitTestCase#testStandaloneRTS
    - org.wildfly.dist.subsystem.xml.StandardConfigsXMLValidationUnitTestCase#testStandaloneXTS
    - org.wildfly.dist.subsystem.xml.StandardConfigsXMLValidationUnitTestCase#testStandaloneGossipHA
    - org.wildfly.dist.subsystem.xml.StandardConfigsXMLValidationUnitTestCase#testStandaloneMicroProfileHA
    - org.wildfly.dist.subsystem.xml.StandardConfigsXMLValidationUnitTestCase#testStandaloneMinimalistic
    - org.wildfly.dist.subsystem.xml.StandardConfigsXMLValidationUnitTestCase#testStandaloneEC2HA
    - org.wildfly.dist.subsystem.xml.StandardConfigsXMLValidationUnitTestCase#testStandaloneMicroProfile
    - org.wildfly.dist.subsystem.xml.StandardConfigsXMLValidationUnitTestCase#testStandaloneGossipFullHA
    - org.wildfly.dist.subsystem.xml.StandardConfigsXMLValidationUnitTestCase#testHostPrimary
    - org.wildfly.dist.subsystem.xml.StandardConfigsXMLValidationUnitTestCase#testStandaloneFull
    - org.wildfly.dist.subsystem.xml.StandardConfigsXMLValidationUnitTestCase#testDomain
    - org.wildfly.dist.subsystem.xml.StandardConfigsXMLValidationUnitTestCase#testStandaloneGenericJMS

wildfly-ee-dist (16)
    - org.wildfly.dist.subsystem.xml.StandardConfigsXMLValidationUnitTestCase#testStandaloneEC2FullHA
    - org.wildfly.dist.subsystem.xml.StandardConfigsXMLValidationUnitTestCase#testHostSecondary
    - org.wildfly.dist.subsystem.xml.StandardConfigsXMLValidationUnitTestCase#testStandalone
    - org.wildfly.dist.subsystem.xml.StandardConfigsXMLValidationUnitTestCase#testHost
    - org.wildfly.dist.subsystem.xml.StandardConfigsXMLValidationUnitTestCase#testStandaloneHA
    - org.wildfly.dist.subsystem.xml.StandardConfigsXMLValidationUnitTestCase#testStandaloneJTS
    - org.wildfly.dist.subsystem.xml.StandardConfigsXMLValidationUnitTestCase#testStandaloneRTS
    - org.wildfly.dist.subsystem.xml.StandardConfigsXMLValidationUnitTestCase#testStandaloneXTS
    - org.wildfly.dist.subsystem.xml.StandardConfigsXMLValidationUnitTestCase#testStandaloneGossipHA
    - org.wildfly.dist.subsystem.xml.StandardConfigsXMLValidationUnitTestCase#testStandaloneMinimalistic
    - org.wildfly.dist.subsystem.xml.StandardConfigsXMLValidationUnitTestCase#testStandaloneEC2HA
    - org.wildfly.dist.subsystem.xml.StandardConfigsXMLValidationUnitTestCase#testStandaloneGossipFullHA
    - org.wildfly.dist.subsystem.xml.StandardConfigsXMLValidationUnitTestCase#testHostPrimary
    - org.wildfly.dist.subsystem.xml.StandardConfigsXMLValidationUnitTestCase#testStandaloneFull
    - org.wildfly.dist.subsystem.xml.StandardConfigsXMLValidationUnitTestCase#testDomain
    - org.wildfly.dist.subsystem.xml.StandardConfigsXMLValidationUnitTestCase#testStandaloneGenericJMS

# [WLFY-#####] Fix Flaky AbstractValidationUnitTest

# Flaky Test Discovery

Using the flaky test discovery tool [NonDex](https://github.com/TestingResearchIllinois/NonDex), we discovered ~137 flaky tests.

This JIRA issue aims to fix a group of ~47 flaky tests in the dist, ee-dist, and preview-dist modules, since there is a common source of flakiness.

To replicate the flaky tests errors:

  1. Setup NonDex
    - `git clone https://github.com/TestingResearchIllinois/NonDex.git`
    - `cd NonDex`
    - `mvn clean install -DskipTests`
  
  2. Run NonDex in Wildfly on the target maven modules:
    - `mvn clean -am -pl dist edu.illinois:nondex-maven-plugin:2.1.7-SNAPSHOT:nondex -Dtest=org.wildfly.dist.subsystem.xml.StandardConfigsXMLValidationUnitTestCase -DnondexRuns=10 -DfailIfNoTests=false`
    - `mvn clean -am -pl ee-dist edu.illinois:nondex-maven-plugin:2.1.7-SNAPSHOT:nondex -Dtest=org.wildfly.dist.subsystem.xml.StandardConfigsXMLValidationUnitTestCase -DnondexRuns=10 -DfailIfNoTests=false`
    - `mvn clean -am -pl preview/dist edu.illinois:nondex-maven-plugin:2.1.7-SNAPSHOT:nondex -Dtest=org.wildfly.dist.subsystem.xml.StandardConfigsXMLValidationUnitTestCase -DnondexRuns=10 -DfailIfNoTests=false`
  
  3. NonDex shuffles the the output of NonDeterministic Java API's (i.e. HashMap keySet()). Some test runs will pass, other runs might fail. For example, in the ee-dist you will see output similar to this:
  ```console
  INFO: Surefire failed when running tests for hBG69zCLvYHCaIKs0AasjTFCdGbX6WTKb05H97ZNIis=
  [INFO] NonDex SUMMARY:
  [INFO] *********
  [INFO] mvn nondex:nondex  -DnondexFilter='.*' -DnondexMode=FULL -DnondexSeed=933178 -DnondexStart=0 -DnondexEnd=9223372036854775807 -DnondexPrintstack=false -DnondexDir="/root/wildfly/ee-dist/.nondex" -DnondexJarDir="/root/wildfly/ee-dist/.nondex" -DnondexExecid=5RBCJBZsiLqnSBfjJ9jn2YW0lSnqn0ab43cDSkQNTg= -DnondexLogging=CONFIG
  [WARNING] org.wildfly.dist.subsystem.xml.StandardConfigsXMLValidationUnitTestCase#testStandaloneEC2FullHA
  [WARNING] org.wildfly.dist.subsystem.xml.StandardConfigsXMLValidationUnitTestCase#testHostSecondary
  [WARNING] org.wildfly.dist.subsystem.xml.StandardConfigsXMLValidationUnitTestCase#testStandalone
  [WARNING] org.wildfly.dist.subsystem.xml.StandardConfigsXMLValidationUnitTestCase#testHost
  [WARNING] org.wildfly.dist.subsystem.xml.StandardConfigsXMLValidationUnitTestCase#testStandaloneHA
  [WARNING] org.wildfly.dist.subsystem.xml.StandardConfigsXMLValidationUnitTestCase#testStandaloneJTS
  [WARNING] org.wildfly.dist.subsystem.xml.StandardConfigsXMLValidationUnitTestCase#testStandaloneRTS
  [WARNING] org.wildfly.dist.subsystem.xml.StandardConfigsXMLValidationUnitTestCase#testStandaloneXTS
  [WARNING] org.wildfly.dist.subsystem.xml.StandardConfigsXMLValidationUnitTestCase#testStandaloneGossipHA
  [WARNING] org.wildfly.dist.subsystem.xml.StandardConfigsXMLValidationUnitTestCase#testStandaloneMinimalistic
  [WARNING] org.wildfly.dist.subsystem.xml.StandardConfigsXMLValidationUnitTestCase#testStandaloneEC2HA
  [WARNING] org.wildfly.dist.subsystem.xml.StandardConfigsXMLValidationUnitTestCase#testStandaloneGossipFullHA
  [WARNING] org.wildfly.dist.subsystem.xml.StandardConfigsXMLValidationUnitTestCase#testHostPrimary
  [WARNING] org.wildfly.dist.subsystem.xml.StandardConfigsXMLValidationUnitTestCase#testStandaloneFull
  [WARNING] org.wildfly.dist.subsystem.xml.StandardConfigsXMLValidationUnitTestCase#testDomain
  [WARNING] org.wildfly.dist.subsystem.xml.StandardConfigsXMLValidationUnitTestCase#testStandaloneGenericJMS
  ```


## Flakiness Cause

Many flaky tests in dist, ee-dist, and preview-dist, rely on a shared parseXml function in `AbstractValidationUnitTest`:

```java
protected void parseXml(String xmlName) throws SAXException, IOException {
    final File xmlFile = getXmlFile(xmlName);
    SchemaFactory schemaFactory = SchemaFactory.newInstance(XMLConstants.W3C_XML_SCHEMA_NS_URI);
    schemaFactory.setErrorHandler(new ErrorHandlerImpl(xmlFile.toPath()));
    schemaFactory.setResourceResolver(DEFAULT_RESOURCE_RESOLVER);
    Schema schema = schemaFactory.newSchema(SCHEMA_SOURCES);
    Validator validator = schema.newValidator();
    validator.setErrorHandler(new ErrorHandlerImpl(xmlFile.toPath()));
    validator.setFeature("http://apache.org/xml/features/validation/schema", true);
    validator.setResourceResolver(DEFAULT_RESOURCE_RESOLVER);
    validator.validate(new StreamSource(xmlFile));

    //noinspection ResultOfMethodCallIgnored
    xmlFile.delete();
}
```

During NonDex runs, the single point of failure is: `Schema schema = schemaFactory.newSchema(SCHEMA_SOURCES);`. The `SCHEMA_SOURCES` is an array of `StreamSource` objects whose order depends on the a nondeterministic listing of files in a directory:

```java
final File schemaDir = new File(JBOSS_DIST_DIR, SCHEMAS_LOCATION);
final File[] xsds = schemaDir.listFiles(new SchemaFilter(EXCLUDED_SCHEMA_FILES.toArray(new String[0])));
```

The files are passed through a series of HashMaps which are read using nondeterministic `keySet()` and `values()` apis to eventually populate `SCHEMA_SOURCES`. However, the order of the `SCHEMA_SOURCES` matters since some schemas may be dependent on each other, (i.e. one schema importing another)

## Fix

Enforce a deterministic order of `SCHEMA_SOURCES`. 

For example, sort the files returned by `schemaDir.listFiles(new SchemaFilter(EXCLUDED_SCHEMA_FILES.toArray(new String[0])));`, convert `JBOSS_SCHEMAS_MAP` to a LinkedHashMap, and convert `CURRENT_JBOSS_SCHEMAS_MAP` to a LinkedHashMap.
